### PR TITLE
Update burn addresses to use 0 characters instead of q

### DIFF
--- a/text/0023-p2wsh-burn-addresses/0023-p2wsh-burn-addresses.md
+++ b/text/0023-p2wsh-burn-addresses/0023-p2wsh-burn-addresses.md
@@ -32,24 +32,71 @@ wallets that support P2WSH.
 Burn addresses shall encode a 32 byte "burn witness program" with the following
 concatenated data:
 
-- 4 bytes application identifier
-- 16 zero bytes
+- 5 bytes application identifier
+- 15 "burn identifier" bytes: `7bdef7bdef7bdef7bdef7bdef7bdef`
 - 12 bytes application specific data
 
-4 bytes are used for the application identifier. This may be anything, but
-should be unique between different applications to avoid conflicts.
+### Application Identifier
 
-The witness program will contain 16 zero bytes after the application ID to
-ensure that it is not possible to brute force an associated spendable script
-(pre-image). 16 bytes corresponds with 128 bits. The current bitcoin hash rate
-corresponds to around 67 bits per second of brute-force and would not come close
-to 128 bits, even after a thousand years.
+The witness program shall start with the application identifier. This will allow
+the start of the bech32 address to begin with a recognisable application prefix.
+The identifiers shall be 5 bytes that are encoded into 8 characters. For
+example, `c9bbb0ff2f` will encode into `example0`.
 
-If a 32 byte P2WSH witness program has 16 zero bytes from index 4, this shall be
-identified by the Peercoin protocol as being "unspendable". Any output
-containing such a program will not be added to the UTXO set. These outputs may
-be identified in the `CScript::IsUnspendable` method, but care must be taken to
-ensure this function is used against output scripts only.
+It is recommended to pad the encoded identifier with `0` characters to the
+right, when less than 8 identifying characters are desired. The bytes
+`7bdef7bdef` will encode into `00000000`.
+
+It is recommended that the application identifiers are unique between different
+applications to avoid conflicts.
+
+### Burn Identifier
+
+The 15 bytes following the application identifier shall be
+`7bdef7bdef7bdef7bdef7bdef7bdef` which shall encode into 24 `0` characters.
+These bytes shall be used to identify burn addresses. The `0` characters make
+the burn addresses easily recognisable.
+
+Because these 15 bytes are fixed, it is not possible to brute force an
+associated spendable script (pre-image). 15 bytes corresponds with 120 bits. The
+current bitcoin hash rate corresponds to around 67 bits per second of
+brute-force and wouldn't reach 120 bits, even after 10 million years.
+
+### Application Specific Data
+
+The final 12 bytes are for application specific data. Applications can identify
+addresses by the application ID and burn identifier, and then use the
+application data for whatever purpose. It is recommended to pad this data to the
+left with `0` characters, using the same repeating 5-bit pattern:
+`7bdef7bdef7bdef7bdef7bde`.
+
+For example, if 3 bytes of data are required to be `010203` then this data can
+packed as `7bdef7bdef7bdef7bd010203` with the required data on the right. This
+encodes as `00000000000000gpqgps`.
+
+### Example Address
+
+If an address was to use `pc1qexample0` as a prefix and `010203` as hex data,
+then the bytes shall be as follows:
+
+    c9bbb0ff2f7bdef7bdef7bdef7bdef7bdef7bdef7bdef7bdef7bdef7bd010203
+
+This encodes into the following address (using the testnet hrp):
+
+    tpc1qexample000000000000000000000000000000000000000gpqgpslnr273
+
+If the data was to include 12 bytes of application data using
+`0102030405060708090a0b0c`, then the address would look like:
+
+    tpc1qexample0000000000000000000000000qypqxpq9qcrsszg2pvxqd4vc49
+
+### Exclusion from UTXO Set
+
+If a 32 byte P2WSH witness program has the 15 byte burn identifier from index 5,
+this shall be identified by the Peercoin protocol as being "unspendable". Any
+output containing such a program will not be added to the UTXO set. These
+outputs may be identified in the `CScript::IsUnspendable` method, but care must
+be taken to ensure this function is used against output scripts only.
 
 The chain state database will need to be updated once to remove any existing
 outputs with burn witness programs.
@@ -63,6 +110,10 @@ date, even after the addresses are being used.
 12 bytes of application specific data is a small amount and may not be suitable
 for all applications, however OP_RETURN is a possible alternative where more
 data is required.
+
+The `0` characters may be hard to manually type as the user would have to count
+them, but most of the time it is expected that the user will use a QR code or
+copy the address.
 
 ## Alternatives
 
@@ -93,16 +144,17 @@ pre-existing burn outputs:
    no impact on consensus as these outputs are unspendable in any case (unless
    SHA-256 is broken to 128-bits).
 
-16 zero bytes may be considered too much. A thousand years worth of bitcoin
+15 zero bytes may be considered too much. A thousand years worth of bitcoin
 mining at the current hash rate is equal to around 100 bits of SHA-256 hashes.
 The zero bytes could be reduced, possibly as low as 12 bytes (96 bits). If there
 ever was a spendable script pre-image found, this would be rendered undependable
 by the new protocol rule in any case and accidental collisions are very
 unlikely.
 
-The 4 byte application ID could also be reduced to 2 (as with port numbers) or 3
-bytes, though this increases the chance of accidental ID collisions or running
-out of ID space.
+The 5 byte application ID could also be reduced to 2 (as with port numbers), 3
+or 4 bytes, though this increases the chance of accidental ID collisions or
+running out of ID space. The length of the prefix characters would be shorter,
+allowing for less recognisable words.
 
 If the zero bytes were reduced to 12 bytes and the application ID down to 2
 bytes, this would leave 18 bytes of application data.


### PR DESCRIPTION
Also changes the app id to 5 bytes and burn id to 15 bytes to align with 5-bit encoding. Examples have been added.